### PR TITLE
Typo fix and expansion of test

### DIFF
--- a/control_auth008.py
+++ b/control_auth008.py
@@ -22,7 +22,7 @@ class Field008(object):
 
     See `LoC's documentation
     <https://www.loc.gov/marc/bibliographic/bd008.html>`_
-    for more infos about those fields.
+    for more info about those fields.
 
     .. code-block:: python
     import control_auth008
@@ -96,7 +96,7 @@ class Field008(object):
     def date_entered(self, value: str) -> None:
         """date_entered (00-05)."""
         if len(value) != 6:
-            raise BadLeaderValue(f"Date Entered is 6 chars field, got {value}")
+            raise BadLeaderValue(f"Date Entered is 6 char field, got {value}")
         self._replace_values(position=0, value=value)
 
     @property
@@ -144,7 +144,7 @@ class Field008(object):
     def record_kind(self, value: str) -> None:
         """record_kind (09)."""
         if len(value) != 1:
-            raise BadLeaderValue(f"Record kind is 1 chars field, got {value}")
+            raise BadLeaderValue(f"Record kind is 1 char field, got {value}")
         self._replace_values(position=9, value=value)
 
     @property
@@ -230,7 +230,7 @@ class Field008(object):
     def heading_use_series(self, value: str) -> None:
         """heading_use_series (16)."""
         if len(value) != 1:
-            raise BadLeaderValue(f"Heading_use_series is 1 chars field, got {value}")
+            raise BadLeaderValue(f"Heading_use_series is 1 char field, got {value}")
         self._replace_values(position=16, value=value)
 
     @property
@@ -340,7 +340,7 @@ class Field008(object):
     def undefined_34(self, value: str) -> None:
         """Subfield code count (34-37)."""
         if len(value) != 4:
-            raise BadLeaderValue(f"undefined_34 is 4 chars field, got {value}")
+            raise BadLeaderValue(f"undefined_34 is 4 char field, got {value}")
         self._replace_values(position=34, value=value)
 
     @property

--- a/control_bib008.py
+++ b/control_bib008.py
@@ -20,7 +20,7 @@ class Field008(object):
 
     See `LoC's documentation
     <https://www.loc.gov/marc/bibliographic/bd008.html>`_
-    for more infos about those fields.
+    for more info about those fields.
 
     .. code-block:: python
     from pymarc import MARCReader
@@ -95,7 +95,7 @@ class Field008(object):
     def date_entered(self, value: str) -> None:
         """date_entered (00-05)."""
         if len(value) != 6:
-            raise BadLeaderValue(f"Date Entered is 6 chars field, got {value}")
+            raise BadLeaderValue(f"Date Entered is 6 char field, got {value}")
         self._replace_values(position=0, value=value)
 
     @property
@@ -119,7 +119,7 @@ class Field008(object):
     def date1(self, value: str) -> None:
         """Date 1 (07-10)."""
         if len(value) != 4:
-            raise BadLeaderValue(f"Date 1 is 4 chars field, got {value}")
+            raise BadLeaderValue(f"Date 1 is 4 char field, got {value}")
         self._replace_values(position=7, value=value)
 
     @property
@@ -143,7 +143,7 @@ class Field008(object):
     def publication_place(self, value: str) -> None:
         """Type of control (08)."""
         if len(value) != 3:
-            raise BadLeaderValue(f"Place of publication is 3 chars field, got {value}")
+            raise BadLeaderValue(f"Place of publication is 3 char field, got {value}")
         self._replace_values(position=15, value=value)
 
     @property

--- a/export_csv.py
+++ b/export_csv.py
@@ -40,8 +40,8 @@ class EXPORT_CSV:
  def normalized_fields_to_csv (self, records_list, tags_list):
   
   '''This function removes all subfield codes and delimters from a field,  
-     and saves the filed into csv file.
-     The csv is column headers are the tags in tags_list
+     and saves the field into a csv file.
+     The csv's column headers are the tags in tags_list
   '''
   fieldnames=[]
   with open(self._csv_filename, 'w', newline='') as csvfile:
@@ -108,11 +108,11 @@ class EXPORT_CSV:
  def db_normalized_to_csv (self, records_list):
   
   '''
-    It extracts records into a sinlge csv file.
+    It extracts records into a single csv file.
     Each record is extracted in rows.
     All rows of a record can be link with a primary key
     and control number in 001.
-    Also, this function retains the squence of tags and subfields.    
+    Also, this function retains the sequence of tags and subfields.    
   '''
   fieldnames=[]
   with open(self._csv_filename, 'w', newline='') as csvfile:

--- a/pymarc_utilities.py
+++ b/pymarc_utilities.py
@@ -184,20 +184,20 @@ class FIND_AND_REPLACE:
       Use this function if you want to make the vernacular field 
       the main fields, and the Romainzed fields are the linked fields
       It converts this:
-      =100  1\$6880-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
-      =880  1\$6100-01/(3/r‏$a‏مصطفى، عبد العزيز.
+      =100  1#$6880-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
+      =880  1#$6100-01/(3/r‏$a‏مصطفى، عبد العزيز.
       =245  10$6880-02$aQabla an yuhdama al-Aqṣá /$cʻAbd al-ʻAzīz Muṣṭafá.
       =880  10$6245-02/(3/r‏$a‏قبل ا يهدم الأقصى /‏$c‏عبد العزيز مصطفى.
-      =260  \\$6880-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
-      =880  \\$6260-03/(3/r‏$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
+      =260  ##$6880-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
+      =880  ##$6260-03/(3/r‏$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
       
       To this:
-      =100  1\$6880-01$a‏مصطفى، عبد العزيز.
+      =100  1#$6880-01$a‏مصطفى، عبد العزيز.
       =245  10$6880-02$a‏قبل ا يهدم الأقصى /‏$c‏عبد العزيز مصطفى.
-      =260  \\$6880-03$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
-      =880  1\$6100-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
+      =260  ##$6880-03$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
+      =880  1#$6100-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
       =880  10$6245-02$aQabla an yuhdama al-Aqṣá /$cʻAbd al-ʻAzīz Muṣṭafá.
-      =880  \\$6260-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
+      =880  ##$6260-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
 
       
       '''

--- a/pymarc_utilities.py
+++ b/pymarc_utilities.py
@@ -14,7 +14,7 @@ class ENCODING:
 
      
 #replace combined UTF-8 characters+diacritics to uncombined characters
-#For example: change ā to ā   
+#For example: change ā (U+0101) to ā   ((U+0061 U+0304)
  def uncombine_diacritics(self, record, skip_subfield_code):
        
        try:
@@ -33,7 +33,7 @@ class ENCODING:
                       )
                 #Loop on subfields
                 for subfield in field:
-                    #Skip $1 in authority files because it throw errors
+                    #Skip $1 in authority files because it throws errors
                     #Subfields' values with slash or backslash may throw errors
                     if subfield[0] != skip_subfield_code:
                        val=subfield[1]
@@ -178,26 +178,26 @@ class FIND_AND_REPLACE:
 
  def swap_bib_linked_fields(record):
     '''
-      Test sawp linked fields
+      Test swap linked fields
       The swap function makes the 880 fields the main fields
       and converts the main fields into linked fields 880
       Use this function if you want to make the vernacular field 
       the main fields, and the Romainzed fields are the linked fields
       It converts this:
-      =100  1#$6880-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
-      =880  1#$6100-01/(3/r‏$a‏مصطفى، عبد العزيز.
+      =100  1\$6880-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
+      =880  1\$6100-01/(3/r‏$a‏مصطفى، عبد العزيز.
       =245  10$6880-02$aQabla an yuhdama al-Aqṣá /$cʻAbd al-ʻAzīz Muṣṭafá.
       =880  10$6245-02/(3/r‏$a‏قبل ا يهدم الأقصى /‏$c‏عبد العزيز مصطفى.
-      =260  ##$6880-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
-      =880  ##$6260-03/(3/r‏$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
+      =260  \\$6880-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
+      =880  \\$6260-03/(3/r‏$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
       
       To this:
-      =100  1#$6880-01$a‏مصطفى، عبد العزيز.
+      =100  1\$6880-01$a‏مصطفى، عبد العزيز.
       =245  10$6880-02$a‏قبل ا يهدم الأقصى /‏$c‏عبد العزيز مصطفى.
-      =260  ##$6880-03$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
-      =880  1#$6100-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
+      =260  \\$6880-03$a[Riyadh :$b‏س.ن.]،‏$c1989‏$e‏(السويدي، الرياض :‏$f‏طبعة بمطابع دار طيبة)‬
+      =880  1\$6100-01$aMuṣṭafá, ʻAbd al-ʻAzīz.
       =880  10$6245-02$aQabla an yuhdama al-Aqṣá /$cʻAbd al-ʻAzīz Muṣṭafá.
-      =880  ##$6260-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
+      =880  \\$6260-03$a[Riyadh :$bs.n.],$c1989$e(al-Suwaydī, al-Riyāḍ :$fṬubiʻat bi-Maṭābiʻ Dār Ṭaybah)
 
       
       '''
@@ -238,7 +238,7 @@ class FIND_AND_REPLACE:
                           subfields=linked_field.subfields
                           )
                 
-                #Modify $6 values in the swaped filed
+                #Modify $6 values in the swapped field
                 add_newfield.delete_subfield ('6')
                 add_newfield.add_subfield ('6', record[field.tag]['6'], 0)
                        

--- a/pymarc_utilities.py
+++ b/pymarc_utilities.py
@@ -14,7 +14,7 @@ class ENCODING:
 
      
 #replace combined UTF-8 characters+diacritics to uncombined characters
-#For example: change ā to ā   
+#For example: change ā (U+0101) to ā   ((U+0061 U+0304)
  def uncombine_diacritics(self, record, skip_subfield_code):
        
        try:
@@ -33,7 +33,7 @@ class ENCODING:
                       )
                 #Loop on subfields
                 for subfield in field:
-                    #Skip $1 in authority files because it throw errors
+                    #Skip $1 in authority files because it throws errors
                     #Subfields' values with slash or backslash may throw errors
                     if subfield[0] != skip_subfield_code:
                        val=subfield[1]
@@ -178,7 +178,7 @@ class FIND_AND_REPLACE:
 
  def swap_bib_linked_fields(record):
     '''
-      Test sawp linked fields
+      Test swap linked fields
       The swap function makes the 880 fields the main fields
       and converts the main fields into linked fields 880
       Use this function if you want to make the vernacular field 
@@ -238,7 +238,7 @@ class FIND_AND_REPLACE:
                           subfields=linked_field.subfields
                           )
                 
-                #Modify $6 values in the swaped filed
+                #Modify $6 values in the swapped field
                 add_newfield.delete_subfield ('6')
                 add_newfield.add_subfield ('6', record[field.tag]['6'], 0)
                        

--- a/test_find_replace.py
+++ b/test_find_replace.py
@@ -22,7 +22,7 @@ Find field indicators value:
 Find field by field tag only:
   sample_field = Field(tag="900")
 
-Find value in control fieldsL
+Find value in control fields:
 sample_field = Field(tag="008", data='\Bara')
 ***Use regex patterns in data values
 
@@ -103,8 +103,8 @@ with open(input_marcfile, 'rb') as fh:
       Test swap linked fields in bib records
       The swap function makes the 880 fields the main fields
       and converts the main fields into linked fields 880
-      Use this function if you want to make the vernacular field 
-      the main fields, and the Romainzed fields are the linked fields
+      Use this function if you want to make the vernacular fields 
+      the main fields, and the Romanized fields are the linked fields
       '''
       if test_swap:
         #Swap linked fields in records where 008.language='ara'

--- a/test_uncombine.py
+++ b/test_uncombine.py
@@ -2,7 +2,6 @@
 
 #PyMARC API documentation https://pymarc.readthedocs.io/en/latest/#api-docs
 
-
 '''
 Combine characters examples : ḥ ḍ ā ī á
 Uncombine characters examples: Ḥ ḍ ā ī
@@ -18,8 +17,8 @@ from pymarc import *
 modf = pymarc_utilities.ENCODING()
 findit = pymarc_utilities.FIND_AND_REPLACE
 
-#If set to True, processes all files in input MARC file. 
-#If set to False, processes only records with containing specific diacritics in 100$a.
+#If uncombine_all is set to True, processes all files in input MARC file. 
+#If uncombine_all is set to False, processes only records with containing specific diacritics in 100$a.
 uncombine_all = False
 #If uncombine_all is False, and ask_each_time is True, record will display and user will decide to write out.
 ask_each_time = False
@@ -30,11 +29,12 @@ output_marcfile='authfiles/FASTPersonal_9.uncomb.mrc'
 
 extracted_rec = Record()
 
-
 #Uncombine MARC file 
 with open(input_marcfile, 'rb') as fh:
     recnum = 0
     extractednum = 0
+    found = 0
+    converted = 0
     reader = MARCReader(fh)
     for record in reader:
       recnum += 1 #Records count
@@ -60,15 +60,12 @@ with open(input_marcfile, 'rb') as fh:
         except:
         #Dummy line
         #Add your own except code
-          a = 0
-        
+          a = 0        
       else:
         '''Perfom the function only if certain criteria is found in the record
            Uncombine the record only if 100$a has any
            of the following combine characters āūīḥḍ
         '''
-        found = 0
-        converted = 0
         sample_field = Field(tag="100", indicators=["?", "?"],
                     subfields=[Subfield(code="a", value="[āūīḥḍ]")])
         is_found = findit.find(record, sample_field)
@@ -80,18 +77,17 @@ with open(input_marcfile, 'rb') as fh:
             #compare length of original string with uncombined diacritics string to test if uncombine happened
             if len(origauth) < len(modauth):
               converted += 1
-            if write_out_records:
-              if ask_each_time:
-                print (extracted_rec)
-                user_input = input("Save to MARC file? 'y' : ")
-              else:
-                 user_input = "y"
-              if user_input == 'y':
-                extractednum += 1
-                with open('exrt377aARA_Diac.mrc', 'ab') as out:
-                  out.write(extracted_rec.as_marc())
-
+              if write_out_records:
+                if ask_each_time:
+                  print (extracted_rec)
+                  user_input = input("Save to MARC file? 'y' : ")
+                else:
+                  user_input = "y"
+                if user_input == 'y':
+                  extractednum += 1
+                  with open('exrt377aARA_Diac.mrc', 'ab') as out:
+                    out.write(extracted_rec.as_marc())
     if not uncombine_all:
-       print(f"Number of diacritic records found: {found}. Number of records uncombined: {converted}.y")
-    print (f"Total processed records : {extractednum} of {recnum}")
+       print(f"Number of diacritic records found: {found}. Number of records converted to uncombined: {converted}.")
+    print (f"Total extracted records : {extractednum} of {recnum}")
     

--- a/test_uncombine.py
+++ b/test_uncombine.py
@@ -4,7 +4,7 @@
 
 
 '''
- Combine characters examples : ḥ ḍ ā ī á
+Combine characters examples : ḥ ḍ ā ī á
 Uncombine characters examples: Ḥ ḍ ā ī
 '''
 
@@ -18,7 +18,13 @@ from pymarc import *
 modf = pymarc_utilities.ENCODING()
 findit = pymarc_utilities.FIND_AND_REPLACE
 
+#If set to True, processes all files in input MARC file. 
+#If set to False, processes only records with containing specific diacritics in 100$a.
 uncombine_all = False
+#If uncombine_all is False, and ask_each_time is True, record will display and user will decide to write out.
+ask_each_time = False
+#If uncombine_all is False, and write_out_records is False, no records will be written out.
+write_out_records = False
 input_marcfile='authfiles/FASTPersonal_9.mrc'
 output_marcfile='authfiles/FASTPersonal_9.uncomb.mrc'
 
@@ -33,7 +39,7 @@ with open(input_marcfile, 'rb') as fh:
     for record in reader:
       recnum += 1 #Records count
       if uncombine_all:
-      #Uncombaine all records in the file
+      #Uncombine all records in the file
         
         try:
           '''
@@ -61,17 +67,31 @@ with open(input_marcfile, 'rb') as fh:
            Uncombine the record only if 100$a has any
            of the following combine characters āūīḥḍ
         '''
+        found = 0
+        converted = 0
         sample_field = Field(tag="100", indicators=["?", "?"],
                     subfields=[Subfield(code="a", value="[āūīḥḍ]")])
         is_found = findit.find(record, sample_field)
         if is_found:
+            found += 1
+            origauth = record.get_fields('100')[0]['a']
             extracted_rec = modf.uncombine_diacritics(record, '?')
-            print(extracted_rec)   
-            user_input = input("Save to MARC file? 'y' : ")
-            if user_input == 'y':
-               extractednum += 1
-               with open('exrt377aARA_Diac.mrc', 'ab') as out:
-                    out.write(extracted_rec.as_marc())
+            modauth = extracted_rec.get_fields('100')[0]['a']
+            #compare length of original string with uncombined diacritics string to test if uncombine happened
+            if len(origauth) < len(modauth):
+              converted += 1
+            if write_out_records:
+              if ask_each_time:
+                print (extracted_rec)
+                user_input = input("Save to MARC file? 'y' : ")
+              else:
+                 user_input = "y"
+              if user_input == 'y':
+                extractednum += 1
+                with open('exrt377aARA_Diac.mrc', 'ab') as out:
+                  out.write(extracted_rec.as_marc())
 
+    if not uncombine_all:
+       print(f"Number of diacritic records found: {found}. Number of records uncombined: {converted}.y")
     print (f"Total processed records : {extractednum} of {recnum}")
     


### PR DESCRIPTION
This pull request includes changes in six files. Five of the six files are solely typo fixes in the comments.

The sixth file (test_uncombine.py) contains an expanded test section for diacritics processing. In looking at this, we did not feel that seeing the output would clearly demonstrate that the combined diacritics had been changed to uncombined diacritics. Therefore, we set up a test that uncombined the diacritics and then compared the original character string with the processed character string by length. In addition, we created switches to allow someone to process the file without having to answer yes to the option to save to MARC file as well as choosing not to print to the MARC file at all.